### PR TITLE
Sort order and invocation error

### DIFF
--- a/mcon/pl/locate.pl
+++ b/mcon/pl/locate.pl
@@ -122,7 +122,7 @@ sub units_path {
 	print "Locating in $MC/$dir...\n" if $main'opt_v;
 	@contents = readdir DIR;			# Slurp the whole thing
 	closedir DIR;						# And close dir, ready for recursion
-	foreach (@contents) {
+	foreach (sort @contents) {
 		next if $_ eq '.' || $_ eq '..';
 		if (/\.U$/) {					# A unit, definitely
 			($unit_name) = /^(.*)\.U$/;

--- a/mcon/pl/order.pl
+++ b/mcon/pl/order.pl
@@ -33,7 +33,7 @@ sub solve_dependencies {
 			# Ignore conditional symbol request
 		} else {
 			chop;
-			system;
+			system $_;
 		}
 	}
 	chdir($WD) || die "Can't chdir to $WD: $!.\n";


### PR DESCRIPTION
To have people on different machines to generate the same Configure, order is vital.

The "system" command does not take $_ as default argument
