### PR TITLE
Fix RT [perl #72156] Re: Perl 5.12.0 RC 0 - Pager detection

### DIFF
--- a/mcon/U/pager.U
+++ b/mcon/U/pager.U
@@ -46,12 +46,15 @@ case "$pager" in
 	esac
 	;;
 *)	dflt="$pager"
-?X: Instruct ./getfile to trust the hinted or previous pager value,
-?X: even if it does not begin with a slash.  For example, on os2,
-?X: pager might be cmd /c more.  See comments in Getfile.U.
-	fn="f/($pager)"
 	;;
 esac
+?X: Instruct ./getfile to trust the default pager value,
+?X: even if it does not begin with a slash.  For example, on os2,
+?X: pager might be cmd /c more.  Also, it might include some options,
+?X: such as '/usr/bin/less -R'.  ./getfile would report that
+?X: "/usr/bin/less -R" doesn't exist.
+?X: See comments in Getfile.U.
+fn="f/($dflt)"
 echo " "
 rp='What pager is used on your system?'
 . ./getfile


### PR DESCRIPTION
Author: Andy Dougherty doughera@lafayete.edu  2012-08-02 20:16:47

Instruct ./getfile to trust the default pager value.  It might not begin
with a slash, or it might include some options, such as"/usr/bin/less -R".  This patch copies the pager.U file from the
dist-3.5 directory, and then changes the 'fn=' line to trust the default.
