### PR TITLE
Escape ~ as some shells expand tilde during here-doc expansion

### DIFF
--- a/mcon/U/Filexp.U
+++ b/mcon/U/Filexp.U
@@ -31,11 +31,15 @@
 cat >filexp <<EOSS
 $startsh
 : expand filename
+?X:
+?X: The case entries below escape the ~ as some shells have shown expansion
+?X: of the ~ during here-doc processing.
+?X:
 case "\$1" in
- ~/*|~)
+ \~/*|\~)
 	echo \$1 | $sed "s|~|\${HOME-\$LOGDIR}|"
 	;;
- ~*)
+ \~*)
 	if $test -f /bin/csh; then
 		/bin/csh -f -c "glob \$1"
 		failed=\$?


### PR DESCRIPTION
Could it be that some broken shells would expand the leading ~ during
the here-document processing?

If that is so, my suggestion is to include ?X: lines in the unit to
explicitly document that fact so that nobody mistakenly removes the
escaping later on, thinking it is not required.

This is my guess, but I have never encountered that problem anywhere, which
is why the "official" dist does not escape the ~.

However, Perl is compiled in much more diverse platorms as gtk-gnutella is
so it would not surprise me... the hard part will be to remember on which
platform the problem was spotted :-)

Cheers,
Raphael
