### PR TITLE
disable messaging on freebsd if not configured

### DIFF
--- a/mcon/U/d_msg.U
+++ b/mcon/U/d_msg.U
@@ -12,7 +12,7 @@
 ?RCS: Revision 3.0  1993/08/18  12:06:37  ram
 ?RCS: Baseline for dist 3.0 netwide release.
 ?RCS:
-?MAKE:d_msg: test d_msgctl d_msgget d_msgsnd d_msgrcv Setvar Findhdr
+?MAKE:d_msg: test d_msgctl d_msgget d_msgsnd d_msgrcv Setvar Findhdr osname
 ?MAKE:	-pick add $@ %<
 ?S:d_msg:
 ?S:	This variable conditionally defines the HAS_MSG symbol, which
@@ -31,6 +31,25 @@ h_msg=true
 echo " "
 case "$d_msgctl$d_msgget$d_msgsnd$d_msgrcv" in
 *"$undef"*) h_msg=false;;
+esac
+case "$osname" in
+freebsd)
+    case "`ipcs 2>&1`" in
+    "SVID messages"*"not configured"*)
+	echo "Your $osname does not have the msg*(2) configured." >&4
+        h_msg=false
+	val="$undef"
+	set msgctl d_msgctl
+	eval $setvar
+	set msgget d_msgget
+	eval $setvar
+	set msgsnd d_msgsnd
+	eval $setvar
+	set msgrcv d_msgrcv
+	eval $setvar
+	;;
+    esac
+    ;;
 esac
 : we could also check for sys/ipc.h ...
 if $h_msg && $test `./findhdr sys/msg.h`; then


### PR DESCRIPTION
I cannot find the original commit message to this fix in the
perl tree, but - even if outdated - seems very legit