### PR TITLE
fix @wiping initialization

### DIFF
--- a/mcon/pl/lint.pl
+++ b/mcon/pl/lint.pl
@@ -110,7 +110,8 @@ sub init_extraction {
 	@make = ();					# Records make dependency lines
 	$body = 'p_body';			# Procedure to handle body
 	$ending = 'p_end';			# Called at the end of each unit
-	@wiping = qw( 				# The keywords we recognize for "wiped" units
+	@wiping =				# The keywords we recognize for "wiped" units
+	qw(
 		PACKAGENAME
 		MAINTLOC
 		VERSION


### PR DESCRIPTION
qw(...) cannot contain comments. The previous "comment" was interpreted as part of the qw list.