### PR TITLE
Feature proposal: "-X exclusions-file" option for mconfig

### DIFF
--- a/bin/packinit.SH
+++ b/bin/packinit.SH
@@ -196,8 +196,9 @@ print <<'EOM';
 
 If your package sources contains symbols that metaconfig will mistake for the
 names of symbols defined by its units, you can list them in an exclusions file.
-(See the documentation of "mconfig -X".) What file would you like metaconfig to
-consult for those symbols? Say "none" if you don't need to exclude any symbols.
+(See the documentation of "metaconfig -X".) What file would you like metaconfig
+to consult for those symbols? Say "none" if you don't need to exclude any
+symbols.
 
 EOM
 $exclusions_file = &myread('File to consult for excluded symbols?', $dflt);

--- a/bin/packinit.SH
+++ b/bin/packinit.SH
@@ -191,6 +191,18 @@ EOM
 $shext = &myread('Additional file extensions to identify SH files?', $dflt);
 $shext = '' if $shext eq 'none';
 
+$dflt = 'none';
+print <<'EOM';
+
+If your package sources contains symbols that metaconfig will mistake for the
+names of symbols defined by its units, you can list them in an exclusions file.
+(See the documentation of "mconfig -X".) What file would you like metaconfig to
+consult for those symbols? Say "none" if you don't need to exclude any symbols.
+
+EOM
+$exclusions_file = &myread('File to consult for excluded symbols?', $dflt);
+$exclusions_file = '' if $exclusions_file eq 'none';
+
 $dflt = $copyright eq ' ' ? 'n' : 'y';
 print <<'EOM';
 
@@ -426,6 +438,8 @@ changercs=$changercs
 : File lookup extensions
 cext='$cext'
 shext='$shext'
+: File to consult for symbol exclusions
+exclusions_file='$exclusions_file'
 : Mailing list variables
 list_users='$list_users'
 list_name='$list_name'

--- a/kit/makedist.SH
+++ b/kit/makedist.SH
@@ -273,7 +273,7 @@ sub manimake {
 Filename                   Kit Description
 --------                   --- -----------
 ";
-	for (sort keys(comment)) {
+	for (sort keys(%comment)) {
 		printf PACKLIST "%-27s %2s %.47s\n", $_, $kit{$_}, $comment{$_};
 	}
 	close PACKLIST;

--- a/mcon/man/mconfig.SH
+++ b/mcon/man/mconfig.SH
@@ -539,6 +539,8 @@ but not need the unit that determines whether \fIstrcpy\fR or \fIindex\fR
 should be used.)
 The \fIfile\fR can contain blank lines, comment lines introduced with '#', and
 lines containing a single symbol.
+If this option is not supplied, any \fI$exclusions_file\fR variable in
+\fI.package\fR is honored instead.
 '''
 ''' T u t o r i a l
 '''

--- a/mcon/man/mconfig.SH
+++ b/mcon/man/mconfig.SH
@@ -528,6 +528,17 @@ option permanently.
 .TP
 .B \-V
 Print version number and exit.
+.TP
+\fB\-X\fI file\fR
+When examining the source files, ignore any symbols listed in the \fIfile\fR.
+This is useful in situations where a particular unit is known not to be needed
+for your package's portability targets, but your source files nevertheless
+contain occurrences of words that look to \fImetaconfig\fR like symbols defined
+in that unit. (For example, you might need the word "index" in a source file,
+but not need the unit that determines whether \fIstrcpy\fR or \fIindex\fR
+should be used.)
+The \fIfile\fR can contain blank lines, comment lines introduced with '#', and
+lines containing a single symbol.
 '''
 ''' T u t o r i a l
 '''

--- a/mcon/man/mxref.SH
+++ b/mcon/man/mxref.SH
@@ -110,6 +110,8 @@ but not need the unit that determines whether \fIstrcpy\fR or \fIindex\fR
 should be used.)
 The \fIfile\fR can contain blank lines, comment lines introduced with '#', and
 lines containing a single symbol.
+If this option is not supplied, any \fI$exclusions_file\fR variable in
+\fI.package\fR is honored instead.
 .SH AUTHOR
 Harlan Stenn <harlan@mumps.pfcs.com>
 .SH FILES

--- a/mcon/man/mxref.SH
+++ b/mcon/man/mxref.SH
@@ -99,6 +99,17 @@ can be found).
 .TP
 .B \-V
 Print version number and exit.
+.TP
+\fB\-X\fI file\fR
+When examining the source files, ignore any symbols listed in the \fIfile\fR.
+This is useful in situations where a particular unit is known not to be needed
+for your package's portability targets, but your source files nevertheless
+contain occurrences of words that look to \fImetaconfig\fR like symbols defined
+in that unit. (For example, you might need the word "index" in a source file,
+but not need the unit that determines whether \fIstrcpy\fR or \fIindex\fR
+should be used.)
+The \fIfile\fR can contain blank lines, comment lines introduced with '#', and
+lines containing a single symbol.
 .SH AUTHOR
 Harlan Stenn <harlan@mumps.pfcs.com>
 .SH FILES

--- a/mcon/mconfig.SH
+++ b/mcon/mconfig.SH
@@ -166,7 +166,7 @@ Usage: metaconfig [-dhkmostvwGMV] [-L dir] [-X file]
   -L : specify main units repository.
   -M : activate production of confmagic.h.
   -V : print version number and exits.
-  -X : read symbol exclusions from FILE (overriding .package)
+  -X : read symbol exclusions from file (overriding .package)
 EOH
 	exit 1;
 }

--- a/mcon/mconfig.SH
+++ b/mcon/mconfig.SH
@@ -68,8 +68,10 @@ chop($date = `date`);
 &profile;						# Read ~/.dist_profile
 
 use Getopt::Std;
-&usage unless getopts("dhkmostvwGMVL:");
+&usage unless getopts("dhkmostvwGMVL:X:");
 
+my %excluded_symbol;
+read_exclusions($opt_X) if defined $opt_X;
 $MC = $opt_L if $opt_L;			# May override public library path
 $MC = &tilda_expand($MC);		# ~name expansion
 chop($WD = `pwd`);				# Working directory
@@ -164,6 +166,7 @@ Usage: metaconfig [-dhkmostvwGMV] [-L dir]
   -L : specify main units repository.
   -M : activate production of confmagic.h.
   -V : print version number and exits.
+  -X FILE : read symbol exclusions from FILE
 EOH
 	exit 1;
 }

--- a/mcon/mconfig.SH
+++ b/mcon/mconfig.SH
@@ -152,7 +152,7 @@ sub init_except {
 # Print out metaconfig's usage and exits
 sub usage {
 	print STDERR <<'EOH';
-Usage: metaconfig [-dhkmostvwGMV] [-L dir]
+Usage: metaconfig [-dhkmostvwGMV] [-L dir] [-X file]
   -d : debug mode.
   -h : print this help message and exits.
   -k : keep temporary directory.
@@ -166,7 +166,7 @@ Usage: metaconfig [-dhkmostvwGMV] [-L dir]
   -L : specify main units repository.
   -M : activate production of confmagic.h.
   -V : print version number and exits.
-  -X FILE : read symbol exclusions from FILE
+  -X : read symbol exclusions from FILE
 EOH
 	exit 1;
 }

--- a/mcon/mconfig.SH
+++ b/mcon/mconfig.SH
@@ -71,7 +71,7 @@ use Getopt::Std;
 &usage unless getopts("dhkmostvwGMVL:X:");
 
 my %excluded_symbol;
-read_exclusions($opt_X) if defined $opt_X;
+read_exclusions($opt_X);
 $MC = $opt_L if $opt_L;			# May override public library path
 $MC = &tilda_expand($MC);		# ~name expansion
 chop($WD = `pwd`);				# Working directory
@@ -166,7 +166,7 @@ Usage: metaconfig [-dhkmostvwGMV] [-L dir] [-X file]
   -L : specify main units repository.
   -M : activate production of confmagic.h.
   -V : print version number and exits.
-  -X : read symbol exclusions from FILE
+  -X : read symbol exclusions from FILE (overriding .package)
 EOH
 	exit 1;
 }

--- a/mcon/mxref.SH
+++ b/mcon/mxref.SH
@@ -60,10 +60,12 @@ $spitshell >>mxref <<'!NO!SUBS!'
 &profile;						# Read ~/.dist_profile
 
 use Getopt::Std;
-&usage unless getopts("df:hkmsVL:");
+&usage unless getopts("df:hkmsVL:X:");
 
 chop($date = `date`);
 chop($WD = `pwd`);				# Working directory
+my %excluded_symbol;
+read_exclusions($opt_X) if defined $opt_X;
 $MC = $opt_L if $opt_L;			# May override  library path
 $MC = &tilda_expand($MC);		# ~name expansion
 chdir $MC || die "Can't chdir to $MC: $!\n";
@@ -119,7 +121,7 @@ sub init_except {
 # Print out metaxref's usage and exits
 sub usage {
 	print STDERR <<EOM;
-Usage: metaxref [-dhkmsV] [-f manifest] [-L dir]
+Usage: metaxref [-dhkmsV] [-f manifest] [-L dir] [-X file]
   -d : debug mode.
   -f : use that file as manifest instead of MANIFEST.new.
   -h : print this help message and exits.
@@ -128,6 +130,7 @@ Usage: metaxref [-dhkmsV] [-f manifest] [-L dir]
   -s : silent mode.
   -L : specify main units repository.
   -V : print version number and exits.
+  -X : read symbol exclusions from FILE
 EOM
 	exit 1;
 }

--- a/mcon/mxref.SH
+++ b/mcon/mxref.SH
@@ -130,7 +130,7 @@ Usage: metaxref [-dhkmsV] [-f manifest] [-L dir] [-X file]
   -s : silent mode.
   -L : specify main units repository.
   -V : print version number and exits.
-  -X : read symbol exclusions from FILE (overriding .package)
+  -X : read symbol exclusions from file (overriding .package)
 EOM
 	exit 1;
 }

--- a/mcon/mxref.SH
+++ b/mcon/mxref.SH
@@ -65,7 +65,7 @@ use Getopt::Std;
 chop($date = `date`);
 chop($WD = `pwd`);				# Working directory
 my %excluded_symbol;
-read_exclusions($opt_X) if defined $opt_X;
+read_exclusions($opt_X);
 $MC = $opt_L if $opt_L;			# May override  library path
 $MC = &tilda_expand($MC);		# ~name expansion
 chdir $MC || die "Can't chdir to $MC: $!\n";
@@ -130,7 +130,7 @@ Usage: metaxref [-dhkmsV] [-f manifest] [-L dir] [-X file]
   -s : silent mode.
   -L : specify main units repository.
   -V : print version number and exits.
-  -X : read symbol exclusions from FILE
+  -X : read symbol exclusions from FILE (overriding .package)
 EOM
 	exit 1;
 }

--- a/mcon/pl/depend.pl
+++ b/mcon/pl/depend.pl
@@ -52,6 +52,9 @@ sub p_wanted {
 		$cmaster{$_} = undef;					# Asks for look-up in C files
 		$cwanted{$_} = "$active" if $active;	# Shell symbols to activate
 	}
+
+	delete @cmaster{keys %excluded_symbol};
+	delete @cwanted{keys %excluded_symbol};
 }
 
 # Process the ?INIT: lines

--- a/mcon/pl/files.pl
+++ b/mcon/pl/files.pl
@@ -29,6 +29,9 @@
 ;# extensions to their packages. For instance, perl5 adds .xs files holding
 ;# some C symbols.
 ;#
+;# The read_exclusions() routine honours the .package $exclusions_file
+;# variable if its argument is undefined.
+;#
 # Extract filenames from manifest
 sub extract_filenames {
 	&build_filext;			# Construct &is_cfile and &is_shfile
@@ -108,6 +111,10 @@ sub q {
 
 sub read_exclusions {
 	my ($filename) = @_;
+	if (!defined $filename) {
+		$filename = $exclusions_file; # default to name from .package
+		return if !defined $filename || $filename eq '';
+	}
 	print "Reading exclusions from $filename...\n" unless $opt_s;
 	open(EXCLUSIONS, "< $filename\0") || die "Can't read $filename: $!\n";
 	local $_;

--- a/mcon/pl/files.pl
+++ b/mcon/pl/files.pl
@@ -106,3 +106,22 @@ sub q {
 	$_;
 }
 
+sub read_exclusions {
+	my ($filename) = @_;
+	print "Reading exclusions from $filename...\n" unless $opt_s;
+	open(EXCLUSIONS, "< $filename\0") || die "Can't read $filename: $!\n";
+	local $_;
+	while (<EXCLUSIONS>) {
+		if (/^\s*#|^\s*$/) {
+			# comment or blank line, ignore
+		}
+		elsif (/^\s*(\w+)\s*$/) {
+			$excluded_symbol{$1} = 1;
+		}
+		else {
+			die "$filename:$.: unrecognised line\n";
+		}
+	}
+	close(EXCLUSIONS) || die "Can't close $filename: $!\n";
+}
+

--- a/mcon/pl/wanted.pl
+++ b/mcon/pl/wanted.pl
@@ -39,25 +39,6 @@
 ;#
 ;# The manifake() routine has to be provided externally.
 ;#
-sub read_exclusions {
-	my ($filename) = @_;
-	print "Reading exclusions from $filename...\n" unless $opt_s;
-	open(EXCLUSIONS, "< $filename\0") || die "Can't read $filename: $!\n";
-	local $_;
-	while (<EXCLUSIONS>) {
-		if (/^\s*#|^\s*$/) {
-			# comment or blank line, ignore
-		}
-		elsif (/^\s*(\w+)\s*$/) {
-			$excluded_symbol{$1} = 1;
-		}
-		else {
-			die "$filename:$.: unrecognised line\n";
-		}
-	}
-	close(EXCLUSIONS) || die "Can't close $filename: $!\n";
-}
-
 # Build a wanted file from the files held in @SHlist and @clist arrays
 sub build_wanted {
 	# If wanted file is already there, parse it to map obsolete if -o option

--- a/mcon/pl/wanted.pl
+++ b/mcon/pl/wanted.pl
@@ -39,6 +39,25 @@
 ;#
 ;# The manifake() routine has to be provided externally.
 ;#
+sub read_exclusions {
+	my ($filename) = @_;
+	print "Reading exclusions from $filename...\n" unless $opt_s;
+	open(EXCLUSIONS, "< $filename\0") || die "Can't read $filename: $!\n";
+	local $_;
+	while (<EXCLUSIONS>) {
+		if (/^\s*#|^\s*$/) {
+			# comment or blank line, ignore
+		}
+		elsif (/^\s*(\w+)\s*$/) {
+			$excluded_symbol{$1} = 1;
+		}
+		else {
+			die "$filename:$.: unrecognised line\n";
+		}
+	}
+	close(EXCLUSIONS) || die "Can't close $filename: $!\n";
+}
+
 # Build a wanted file from the files held in @SHlist and @clist arrays
 sub build_wanted {
 	# If wanted file is already there, parse it to map obsolete if -o option

--- a/mcon/pl/xref.pl
+++ b/mcon/pl/xref.pl
@@ -55,6 +55,9 @@ sub p_wanted {
 		$cwanted{$_} = "$fake";					# Attached to this symbol
 		push(@Master, "?$unit:$fake=''");		# Fake initialization
 	}
+
+	delete @cmaster{keys %excluded_symbol};
+	delete @cwanted{keys %excluded_symbol};
 }
 
 # Ingnore the following:

--- a/mcon/pl/xwant.pl
+++ b/mcon/pl/xwant.pl
@@ -49,7 +49,7 @@ sub build_xref {
 		print "    Scanning .[chyl] files for symbols...\n" unless $opt_s;
 		$search = ' ' x (40 * (@cmaster + @ocmaster));	# Pre-extend
 		$search = "while (<>) {study;\n";				# Init loop over ARGV
-		foreach $key (keys(cmaster)) {
+		foreach $key (keys(%cmaster)) {
 			$search .= "\$cmaster{'$key'} .= \"\$ARGV#\" if /\\b$key\\b/;\n";
 		}
 		foreach $key (grep(!/^\$/, keys %Obsolete)) {
@@ -63,7 +63,7 @@ sub build_xref {
 		eval $search;
 		eval '';
 		$/ = "\n";
-		while (($key,$value) = each(cmaster)) {
+		while (($key,$value) = each(%cmaster)) {
 			next if $value eq '';
 			foreach $file (sort(split(/#/, $value))) {
 				next if $file eq '';
@@ -94,7 +94,7 @@ sub build_xref {
 		$search = ' ' x (40 * (@shmaster + @oshmaster));	# Pre-extend
 		$search = "while (<>) {study;\n";
 		# All the keys already have a leading '$'
-		foreach $key (keys(shmaster)) {
+		foreach $key (keys(%shmaster)) {
 			$search .= "\$shmaster{'$key'} .= \"\$ARGV#\" if /\\$key\\b/;\n";
 		}
 		foreach $key (grep (/^\$/, keys %Obsolete)) {
@@ -108,7 +108,7 @@ sub build_xref {
 		eval $search;
 		eval '';
 		$/ = "\n";
-		while (($key,$value) = each(shmaster)) {
+		while (($key,$value) = each(%shmaster)) {
 			next if $value eq '';
 			foreach $file (sort(split(/#/, $value))) {
 				next if $file eq '';


### PR DESCRIPTION
Packages can use this option to list symbols that shouldn't bring in the corresponding units. For example, Perl need not provide support for BSD index(3) as an alternative to C89 strchr(3), but "index" is the name of a Perl builtin, so that string in the source files is misunderstood by metaconfig as an attempt to use the BSD function.

With this change, Perl can deal with this situation by adding "index" (and "rindex") to an exclusion list.

Perl is already using a version of mconfig that includes this new feature:

https://github.com/perl5-metaconfig/metaconfig/commit/c3a1ef25b739b9c71e336133e290fa65cd5fd284
https://github.com/Perl/perl5/commit/92c878fe3be5db4aca79e291be6527e853ca857c

Please let me know what you think — thank you!