### PR TITLE
Fix some syntax errors

### DIFF
--- a/bin/manilist.SH
+++ b/bin/manilist.SH
@@ -213,7 +213,7 @@ if ($opt_d) {
 }
 
 @manifest = sort @manifest;
-@files = sort @files if defined(@files);
+@files = sort @files if @files;
 
 # Build up the %manifest array so that we quickly know whether a file is in the
 # manifest or not.

--- a/kit/makedist.SH
+++ b/kit/makedist.SH
@@ -114,7 +114,7 @@ sub kitbuild {
 		$list = $list[$kitnum];
 		$kit = sprintf("$package.kit" . $sp,$kitnum);
 		print "*** Making $kit ***\n";
-		open(KIT,">$curdir/$kit") || do fatal("Can't create $curdir/$kit: $!");
+		open(KIT,">$curdir/$kit") || &fatal("Can't create $curdir/$kit: $!");
 
 		&kitleader;
 
@@ -202,7 +202,7 @@ sub kitlists {
 	}
 
 	# Build a file PACKNOTES to reconstruct split files
-	if (defined %Chopped) {
+	if (%Chopped) {
 		open(PACKNOTES, ">$PACKNOTES") || &fatal("Can't create PACKNOTES: $!");
 		foreach (keys %Chopped) {
 			print PACKNOTES <<EOC;
@@ -248,9 +248,9 @@ EOC
 
 # Read manifest file and initialize the %comment array.
 sub maniread {
-	do fatal("You don't have a $NEWMANI file.  Run manifake")
+	&fatal("You don't have a $NEWMANI file.  Run manifake")
 		unless -f "$NEWMANI";
-	open(NEWMANI,$NEWMANI) || do fatal("Can't read $NEWMANI: $!");
+	open(NEWMANI,$NEWMANI) || &fatal("Can't read $NEWMANI: $!");
 	while (<NEWMANI>) {
 		($key,$val) = split(' ',$_,1) unless ($key,$val) = /^(\S+)\s+(.*)/;
 		$comment{$key} = $val;
@@ -266,7 +266,7 @@ sub manimake {
 	# Add built packlist
 	$comment{$PACKLIST} = 'Which files came with which kits';
 
-	open(PACKLIST, ">$PACKLIST") || do fatal("Can't create $PACKLIST: $!");
+	open(PACKLIST, ">$PACKLIST") || &fatal("Can't create $PACKLIST: $!");
 	print PACKLIST
 "After all the $package kits are run you should have the following files:
 
@@ -321,7 +321,7 @@ case \$todo in
 	'')
 		echo \"You have run all your kits.\"
 EOM
-	if (defined %Chopped) {		# Some splitting occurred
+	if (%Chopped) {		# Some splitting occurred
 		print KIT <<EOM;
 		if test -f $PACKNOTES; then
 			sh $PACKNOTES

--- a/pl/makedir.pl
+++ b/pl/makedir.pl
@@ -22,7 +22,7 @@ sub makedir {
     local($dir) = $_;
     if (!-d && $_ ne '') {
         # Make dirname first
-        do makedir($_) if s|(.*)/.*|\1|;
+        &makedir($_) if s|(.*)/.*|\1|;
 		mkdir($dir, 0700) if ! -d $dir;
     }
 }

--- a/pl/rcsargs.pl
+++ b/pl/rcsargs.pl
@@ -19,11 +19,11 @@ sub rcsargs {
 	while ($_ = shift(@_)) {
 		if ($_ =~ /^-/) {
 			$result .= $_ . ' ';
-		} elsif ($#_ >= 0 && do equiv($_,$_[0])) {
+		} elsif ($#_ >= 0 && &equiv($_,$_[0])) {
 			$result .= $_ . ' ' . $_[0] . ' ';
 			shift(@_);
 		} else {
-			$result .= $_ . ' ' . do other($_) . ' ';
+			$result .= $_ . ' ' . &other($_) . ' ';
 		}
 	}
 	$result;


### PR DESCRIPTION
This fixes syntax errors in makedist, patbase, patcil, patclean, patcol, patdiff, patname, and patsnap. I can't vouch for the correct functioning of these command, but at least they now compile.