### PR TITLE
Fix man page comment schema

### DIFF
--- a/bin/manicheck.man
+++ b/bin/manicheck.man
@@ -1,18 +1,18 @@
-''' $Id$
-'''
-'''  Copyright (c) 1991-1997, 2004-2006, Raphael Manfredi
-'''  
-'''  You may redistribute only under the terms of the Artistic Licence,
-'''  as specified in the README file that comes with the distribution.
-'''  You may reuse parts of this distribution only within the terms of
-'''  that same Artistic Licence; a copy of which may be found at the root
-'''  of the source tree for dist 4.0.
-'''
-''' $Log: manicheck.man,v $
-''' Revision 3.0  1993/08/18  12:04:02  ram
-''' Baseline for dist 3.0 netwide release.
-'''
-''' 
+.\" $Id$
+.\"
+.\"  Copyright (c) 1991-1997, 2004-2006, Raphael Manfredi
+.\"  
+.\"  You may redistribute only under the terms of the Artistic Licence,
+.\"  as specified in the README file that comes with the distribution.
+.\"  You may reuse parts of this distribution only within the terms of
+.\"  that same Artistic Licence; a copy of which may be found at the root
+.\"  of the source tree for dist 4.0.
+.\"
+.\" $Log: manicheck.man,v $
+.\" Revision 3.0  1993/08/18  12:04:02  ram
+.\" Baseline for dist 3.0 netwide release.
+.\"
+.\" 
 .TH MANICHECK 1 ram
 .SH NAME
 manicheck \- check manifest accuracy

--- a/bin/manilist.man
+++ b/bin/manilist.man
@@ -1,27 +1,27 @@
-''' $Id$
-'''
-'''  Copyright (c) 1991-1997, 2004-2006, Raphael Manfredi
-'''  
-'''  You may redistribute only under the terms of the Artistic Licence,
-'''  as specified in the README file that comes with the distribution.
-'''  You may reuse parts of this distribution only within the terms of
-'''  that same Artistic Licence; a copy of which may be found at the root
-'''  of the source tree for dist 4.0.
-'''
-''' $Log: manilist.man,v $
-''' Revision 3.0.1.3  1995/05/12  11:57:31  ram
-''' patch54: updated my e-mail address
-'''
-''' Revision 3.0.1.2  1994/01/24  13:52:55  ram
-''' patch16: typo fix
-'''
-''' Revision 3.0.1.1  1993/08/24  12:11:02  ram
-''' patch3: typo fix
-'''
-''' Revision 3.0  1993/08/18  12:04:04  ram
-''' Baseline for dist 3.0 netwide release.
-'''
-''' 
+.\" $Id$
+.\"
+.\"  Copyright (c) 1991-1997, 2004-2006, Raphael Manfredi
+.\"  
+.\"  You may redistribute only under the terms of the Artistic Licence,
+.\"  as specified in the README file that comes with the distribution.
+.\"  You may reuse parts of this distribution only within the terms of
+.\"  that same Artistic Licence; a copy of which may be found at the root
+.\"  of the source tree for dist 4.0.
+.\"
+.\" $Log: manilist.man,v $
+.\" Revision 3.0.1.3  1995/05/12  11:57:31  ram
+.\" patch54: updated my e-mail address
+.\"
+.\" Revision 3.0.1.2  1994/01/24  13:52:55  ram
+.\" patch16: typo fix
+.\"
+.\" Revision 3.0.1.1  1993/08/24  12:11:02  ram
+.\" patch3: typo fix
+.\"
+.\" Revision 3.0  1993/08/18  12:04:04  ram
+.\" Baseline for dist 3.0 netwide release.
+.\"
+.\" 
 .TH MANILIST 1 ram
 .SH NAME
 manilist \- report status of files in a source directory

--- a/bin/packinit.man
+++ b/bin/packinit.man
@@ -1,30 +1,30 @@
-''' $Id$
-'''
-'''  Copyright (c) 1991-1997, 2004-2006, Raphael Manfredi
-'''  
-'''  You may redistribute only under the terms of the Artistic Licence,
-'''  as specified in the README file that comes with the distribution.
-'''  You may reuse parts of this distribution only within the terms of
-'''  that same Artistic Licence; a copy of which may be found at the root
-'''  of the source tree for dist 4.0.
-'''
-''' $Log: packinit.man,v $
-''' Revision 3.0.1.4  1995/07/25  13:31:38  ram
-''' patch56: fixed a typo
-'''
-''' Revision 3.0.1.3  1995/05/12  11:57:38  ram
-''' patch54: updated my e-mail address
-'''
-''' Revision 3.0.1.2  1994/10/29  15:45:17  ram
-''' patch36: added new variables cext, shext, changelog and changercs
-'''
-''' Revision 3.0.1.1  1994/01/24  13:54:31  ram
-''' patch16: now documents variables set in .package by packinit
-'''
-''' Revision 3.0  1993/08/18  12:04:06  ram
-''' Baseline for dist 3.0 netwide release.
-'''
-''' 
+.\" $Id$
+.\"
+.\"  Copyright (c) 1991-1997, 2004-2006, Raphael Manfredi
+.\"  
+.\"  You may redistribute only under the terms of the Artistic Licence,
+.\"  as specified in the README file that comes with the distribution.
+.\"  You may reuse parts of this distribution only within the terms of
+.\"  that same Artistic Licence; a copy of which may be found at the root
+.\"  of the source tree for dist 4.0.
+.\"
+.\" $Log: packinit.man,v $
+.\" Revision 3.0.1.4  1995/07/25  13:31:38  ram
+.\" patch56: fixed a typo
+.\"
+.\" Revision 3.0.1.3  1995/05/12  11:57:38  ram
+.\" patch54: updated my e-mail address
+.\"
+.\" Revision 3.0.1.2  1994/10/29  15:45:17  ram
+.\" patch36: added new variables cext, shext, changelog and changercs
+.\"
+.\" Revision 3.0.1.1  1994/01/24  13:54:31  ram
+.\" patch16: now documents variables set in .package by packinit
+.\"
+.\" Revision 3.0  1993/08/18  12:04:06  ram
+.\" Baseline for dist 3.0 netwide release.
+.\"
+.\" 
 .TH PACKINIT 1 ram
 .SH NAME
 packinit \- initialize or update your .package file

--- a/bin/perload
+++ b/bin/perload
@@ -478,9 +478,9 @@ sub q {
 .nr % 0		\" start at page 1
 '; __END__	\" the perl compiler stops here
 
-'''
-''' From here on it's a standard manual page.
-'''
+.\"
+.\" From here on it's a standard manual page.
+.\"
 
 .TH PERLOAD 1 "June 20, 1992"
 .AT 3

--- a/dist.man
+++ b/dist.man
@@ -1,37 +1,37 @@
-''' $Id$
-'''
-'''  Copyright (c) 1991-1997, 2004-2006, Raphael Manfredi
-'''  
-'''  You may redistribute only under the terms of the Artistic Licence,
-'''  as specified in the README file that comes with the distribution.
-'''  You may reuse parts of this distribution only within the terms of
-'''  that same Artistic Licence; a copy of which may be found at the root
-'''  of the source tree for dist 4.0.
-'''
-''' $Log: dist.man,v $
-''' Revision 3.0.1.6  1995/05/12  11:57:53  ram
-''' patch54: updated my e-mail address
-'''
-''' Revision 3.0.1.5  1994/10/29  15:46:03  ram
-''' patch36: mentions new patlog script and ChangeLog file
-'''
-''' Revision 3.0.1.4  1994/05/06  13:54:17  ram
-''' patch23: extended copyright notice to 1994
-''' patch23: new script kitpost
-'''
-''' Revision 3.0.1.3  1994/01/24  13:55:41  ram
-''' patch16: documents profile and its components
-'''
-''' Revision 3.0.1.2  1993/11/10  17:31:03  ram
-''' patch14: added mention for new confmagic.h file
-'''
-''' Revision 3.0.1.1  1993/08/24  12:12:00  ram
-''' patch3: added entries for patnotify and patsnap
-'''
-''' Revision 3.0  1993/08/18  12:04:07  ram
-''' Baseline for dist 3.0 netwide release.
-'''
-''' 
+.\" $Id$
+.\"
+.\"  Copyright (c) 1991-1997, 2004-2006, Raphael Manfredi
+.\"  
+.\"  You may redistribute only under the terms of the Artistic Licence,
+.\"  as specified in the README file that comes with the distribution.
+.\"  You may reuse parts of this distribution only within the terms of
+.\"  that same Artistic Licence; a copy of which may be found at the root
+.\"  of the source tree for dist 4.0.
+.\"
+.\" $Log: dist.man,v $
+.\" Revision 3.0.1.6  1995/05/12  11:57:53  ram
+.\" patch54: updated my e-mail address
+.\"
+.\" Revision 3.0.1.5  1994/10/29  15:46:03  ram
+.\" patch36: mentions new patlog script and ChangeLog file
+.\"
+.\" Revision 3.0.1.4  1994/05/06  13:54:17  ram
+.\" patch23: extended copyright notice to 1994
+.\" patch23: new script kitpost
+.\"
+.\" Revision 3.0.1.3  1994/01/24  13:55:41  ram
+.\" patch16: documents profile and its components
+.\"
+.\" Revision 3.0.1.2  1993/11/10  17:31:03  ram
+.\" patch14: added mention for new confmagic.h file
+.\"
+.\" Revision 3.0.1.1  1993/08/24  12:12:00  ram
+.\" patch3: added entries for patnotify and patsnap
+.\"
+.\" Revision 3.0  1993/08/18  12:04:07  ram
+.\" Baseline for dist 3.0 netwide release.
+.\"
+.\" 
 .de Ex		\" Start of Example
 .sp
 .in +5

--- a/jmake/jmake.man
+++ b/jmake/jmake.man
@@ -1,28 +1,28 @@
-''' $Id$
-'''
-'''  Copyright (c) 1991-1997, 2004-2006, Raphael Manfredi
-'''  
-'''  You may redistribute only under the terms of the Artistic Licence,
-'''  as specified in the README file that comes with the distribution.
-'''  You may reuse parts of this distribution only within the terms of
-'''  that same Artistic Licence; a copy of which may be found at the root
-'''  of the source tree for dist 4.0.
-'''
-''' $Log: jmake.man,v $
-''' Revision 3.0.1.3  2004/08/22 09:01:55  ram
-''' patch71: renamed |test as |case as the construct has its syntax
-''' patch71: added |subst section to allow variable substitutions
-'''
-''' Revision 3.0.1.2  2004/08/21 23:19:52  ram
-''' patch71: added '|shell' section to emit verbatim code in Makefile.SH
-''' patch71: new '|test' to conditionally generate Makefile sections
-'''
-''' Revision 3.0.1.1  1995/05/12  11:57:58  ram
-''' patch54: updated my e-mail address
-'''
-''' Revision 3.0  1993/08/18  12:04:18  ram
-''' Baseline for dist 3.0 netwide release.
-'''
+.\" $Id$
+.\"
+.\"  Copyright (c) 1991-1997, 2004-2006, Raphael Manfredi
+.\"  
+.\"  You may redistribute only under the terms of the Artistic Licence,
+.\"  as specified in the README file that comes with the distribution.
+.\"  You may reuse parts of this distribution only within the terms of
+.\"  that same Artistic Licence; a copy of which may be found at the root
+.\"  of the source tree for dist 4.0.
+.\"
+.\" $Log: jmake.man,v $
+.\" Revision 3.0.1.3  2004/08/22 09:01:55  ram
+.\" patch71: renamed |test as |case as the construct has its syntax
+.\" patch71: added |subst section to allow variable substitutions
+.\"
+.\" Revision 3.0.1.2  2004/08/21 23:19:52  ram
+.\" patch71: added '|shell' section to emit verbatim code in Makefile.SH
+.\" patch71: new '|test' to conditionally generate Makefile sections
+.\"
+.\" Revision 3.0.1.1  1995/05/12  11:57:58  ram
+.\" patch54: updated my e-mail address
+.\"
+.\" Revision 3.0  1993/08/18  12:04:18  ram
+.\" Baseline for dist 3.0 netwide release.
+.\"
 .TH JMAKE 1 ram
 .SH NAME
 jmake \- a generic makefile builder

--- a/jmake/jmkmf.man
+++ b/jmake/jmkmf.man
@@ -1,20 +1,20 @@
-''' $Id$
-'''
-'''  Copyright (c) 1991-1997, 2004-2006, Raphael Manfredi
-'''  
-'''  You may redistribute only under the terms of the Artistic Licence,
-'''  as specified in the README file that comes with the distribution.
-'''  You may reuse parts of this distribution only within the terms of
-'''  that same Artistic Licence; a copy of which may be found at the root
-'''  of the source tree for dist 4.0.
-'''
-''' $Log: jmkmf.man,v $
-''' Revision 3.0.1.1  1995/05/12  11:58:03  ram
-''' patch54: updated my e-mail address
-'''
-''' Revision 3.0  1993/08/18  12:04:20  ram
-''' Baseline for dist 3.0 netwide release.
-'''
+.\" $Id$
+.\"
+.\"  Copyright (c) 1991-1997, 2004-2006, Raphael Manfredi
+.\"  
+.\"  You may redistribute only under the terms of the Artistic Licence,
+.\"  as specified in the README file that comes with the distribution.
+.\"  You may reuse parts of this distribution only within the terms of
+.\"  that same Artistic Licence; a copy of which may be found at the root
+.\"  of the source tree for dist 4.0.
+.\"
+.\" $Log: jmkmf.man,v $
+.\" Revision 3.0.1.1  1995/05/12  11:58:03  ram
+.\" patch54: updated my e-mail address
+.\"
+.\" Revision 3.0  1993/08/18  12:04:20  ram
+.\" Baseline for dist 3.0 netwide release.
+.\"
 .TH JMKMF 1 ram
 .SH NAME
 jmkmf \- runs jmake with the correct options

--- a/kit/kitpost.man
+++ b/kit/kitpost.man
@@ -1,20 +1,20 @@
-''' $Id$
-'''
-'''  Copyright (c) 1991-1997, 2004-2006, Raphael Manfredi
-'''  
-'''  You may redistribute only under the terms of the Artistic Licence,
-'''  as specified in the README file that comes with the distribution.
-'''  You may reuse parts of this distribution only within the terms of
-'''  that same Artistic Licence; a copy of which may be found at the root
-'''  of the source tree for dist 4.0.
-'''
-''' $Log: kitpost.man,v $
-''' Revision 3.0.1.2  1995/05/12  11:58:09  ram
-''' patch54: updated my e-mail address
-'''
-''' Revision 3.0.1.1  1994/05/06  13:55:01  ram
-''' patch23: created
-'''
+.\" $Id$
+.\"
+.\"  Copyright (c) 1991-1997, 2004-2006, Raphael Manfredi
+.\"  
+.\"  You may redistribute only under the terms of the Artistic Licence,
+.\"  as specified in the README file that comes with the distribution.
+.\"  You may reuse parts of this distribution only within the terms of
+.\"  that same Artistic Licence; a copy of which may be found at the root
+.\"  of the source tree for dist 4.0.
+.\"
+.\" $Log: kitpost.man,v $
+.\" Revision 3.0.1.2  1995/05/12  11:58:09  ram
+.\" patch54: updated my e-mail address
+.\"
+.\" Revision 3.0.1.1  1994/05/06  13:55:01  ram
+.\" patch23: created
+.\"
 .TH KITSEND 1 ram
 .SH NAME
 kitpost \- posts distribution kits

--- a/kit/kitsend.man
+++ b/kit/kitsend.man
@@ -1,20 +1,20 @@
-''' $Id$
-'''
-'''  Copyright (c) 1991-1997, 2004-2006, Raphael Manfredi
-'''  
-'''  You may redistribute only under the terms of the Artistic Licence,
-'''  as specified in the README file that comes with the distribution.
-'''  You may reuse parts of this distribution only within the terms of
-'''  that same Artistic Licence; a copy of which may be found at the root
-'''  of the source tree for dist 4.0.
-'''
-''' $Log: kitsend.man,v $
-''' Revision 3.0.1.1  1994/05/06  14:00:11  ram
-''' patch23: documented new -V and -h options
-'''
-''' Revision 3.0  1993/08/18  12:04:26  ram
-''' Baseline for dist 3.0 netwide release.
-'''
+.\" $Id$
+.\"
+.\"  Copyright (c) 1991-1997, 2004-2006, Raphael Manfredi
+.\"  
+.\"  You may redistribute only under the terms of the Artistic Licence,
+.\"  as specified in the README file that comes with the distribution.
+.\"  You may reuse parts of this distribution only within the terms of
+.\"  that same Artistic Licence; a copy of which may be found at the root
+.\"  of the source tree for dist 4.0.
+.\"
+.\" $Log: kitsend.man,v $
+.\" Revision 3.0.1.1  1994/05/06  14:00:11  ram
+.\" patch23: documented new -V and -h options
+.\"
+.\" Revision 3.0  1993/08/18  12:04:26  ram
+.\" Baseline for dist 3.0 netwide release.
+.\"
 .TH KITSEND 1 ram
 .SH NAME
 kitsend \- sends distribution kits

--- a/kit/makeSH.man
+++ b/kit/makeSH.man
@@ -1,18 +1,18 @@
-''' $Id$
-'''
-'''  Copyright (c) 1991-1997, 2004-2006, Raphael Manfredi
-'''  
-'''  You may redistribute only under the terms of the Artistic Licence,
-'''  as specified in the README file that comes with the distribution.
-'''  You may reuse parts of this distribution only within the terms of
-'''  that same Artistic Licence; a copy of which may be found at the root
-'''  of the source tree for dist 4.0.
-'''
-''' $Log: makeSH.man,v $
-''' Revision 3.0  1993/08/18  12:04:27  ram
-''' Baseline for dist 3.0 netwide release.
-'''
-''' 
+.\" $Id$
+.\"
+.\"  Copyright (c) 1991-1997, 2004-2006, Raphael Manfredi
+.\"  
+.\"  You may redistribute only under the terms of the Artistic Licence,
+.\"  as specified in the README file that comes with the distribution.
+.\"  You may reuse parts of this distribution only within the terms of
+.\"  that same Artistic Licence; a copy of which may be found at the root
+.\"  of the source tree for dist 4.0.
+.\"
+.\" $Log: makeSH.man,v $
+.\" Revision 3.0  1993/08/18  12:04:27  ram
+.\" Baseline for dist 3.0 netwide release.
+.\"
+.\" 
 .TH MAKESH 1 LOCAL
 .SH NAME
 makeSH \- a .SH script maker

--- a/kit/makedist.man
+++ b/kit/makedist.man
@@ -1,25 +1,25 @@
 .rn '' }`
-''' $Id$
-'''
-'''  Copyright (c) 1991-1997, 2004-2006, Raphael Manfredi
-'''  
-'''  You may redistribute only under the terms of the Artistic Licence,
-'''  as specified in the README file that comes with the distribution.
-'''  You may reuse parts of this distribution only within the terms of
-'''  that same Artistic Licence; a copy of which may be found at the root
-'''  of the source tree for dist 4.0.
-'''
-''' $Log: makedist.man,v $
-''' Revision 3.0.1.2  1995/05/12  11:58:16  ram
-''' patch54: updated my e-mail address
-'''
-''' Revision 3.0.1.1  1994/05/06  14:00:50  ram
-''' patch23: now mentions kitpost and kitsend
-'''
-''' Revision 3.0  1993/08/18  12:04:31  ram
-''' Baseline for dist 3.0 netwide release.
-'''
-''' 
+.\" $Id$
+.\"
+.\"  Copyright (c) 1991-1997, 2004-2006, Raphael Manfredi
+.\"  
+.\"  You may redistribute only under the terms of the Artistic Licence,
+.\"  as specified in the README file that comes with the distribution.
+.\"  You may reuse parts of this distribution only within the terms of
+.\"  that same Artistic Licence; a copy of which may be found at the root
+.\"  of the source tree for dist 4.0.
+.\"
+.\" $Log: makedist.man,v $
+.\" Revision 3.0.1.2  1995/05/12  11:58:16  ram
+.\" patch54: updated my e-mail address
+.\"
+.\" Revision 3.0.1.1  1994/05/06  14:00:50  ram
+.\" patch23: now mentions kitpost and kitsend
+.\"
+.\" Revision 3.0  1993/08/18  12:04:31  ram
+.\" Baseline for dist 3.0 netwide release.
+.\"
+.\" 
 .de Sh
 .br
 .ne 5
@@ -31,11 +31,11 @@
 .if t .sp .5v
 .if n .sp
 ..
-'''
-'''     Set up \*(-- to give an unbreakable dash;
-'''     string Tr holds user defined translation string.
-'''     Bell System Logo is used as a dummy character.
-'''
+.\"
+.\"     Set up \*(-- to give an unbreakable dash;
+.\"     string Tr holds user defined translation string.
+.\"     Bell System Logo is used as a dummy character.
+.\"
 .ie n \{\
 .tr \(*W-\*(Tr
 .ds -- \(*W-

--- a/kit/manifake.man
+++ b/kit/manifake.man
@@ -1,20 +1,20 @@
-''' $Id$
-'''
-'''  Copyright (c) 1991-1997, 2004-2006, Raphael Manfredi
-'''  
-'''  You may redistribute only under the terms of the Artistic Licence,
-'''  as specified in the README file that comes with the distribution.
-'''  You may reuse parts of this distribution only within the terms of
-'''  that same Artistic Licence; a copy of which may be found at the root
-'''  of the source tree for dist 4.0.
-'''
-''' $Log: manifake.man,v $
-''' Revision 3.0.1.1  1995/05/12  11:58:21  ram
-''' patch54: updated my e-mail address
-'''
-''' Revision 3.0  1993/08/18  12:04:33  ram
-''' Baseline for dist 3.0 netwide release.
-'''
+.\" $Id$
+.\"
+.\"  Copyright (c) 1991-1997, 2004-2006, Raphael Manfredi
+.\"  
+.\"  You may redistribute only under the terms of the Artistic Licence,
+.\"  as specified in the README file that comes with the distribution.
+.\"  You may reuse parts of this distribution only within the terms of
+.\"  that same Artistic Licence; a copy of which may be found at the root
+.\"  of the source tree for dist 4.0.
+.\"
+.\" $Log: manifake.man,v $
+.\" Revision 3.0.1.1  1995/05/12  11:58:21  ram
+.\" patch54: updated my e-mail address
+.\"
+.\" Revision 3.0  1993/08/18  12:04:33  ram
+.\" Baseline for dist 3.0 netwide release.
+.\"
 .TH MANIFAKE 1 ram
 .SH NAME
 manifake \- creates a MANIFEST.new out of a MANIFEST file

--- a/mcon/man/mconfig.SH
+++ b/mcon/man/mconfig.SH
@@ -18,88 +18,88 @@ echo "Extracting mcon/man/metaconfig.$manext (with variable substitutions)"
 $rm -f metaconfig.$manext
 $spitshell >metaconfig.$manext <<!GROK!THIS!
 .TH METACONFIG $manext "Version $VERSION PL$PATCHLEVEL"
-''' @(#) Manual page for metaconfig
-'''
-''' $Id$
-'''
-'''  Copyright (c) 1991-1997, 2004-2006, Raphael Manfredi
-'''  
-'''  You may redistribute only under the terms of the Artistic Licence,
-'''  as specified in the README file that comes with the distribution.
-'''  You may reuse parts of this distribution only within the terms of
-'''  that same Artistic Licence; a copy of which may be found at the root
-'''  of the source tree for dist 4.0.
-'''
-''' $Log: mconfig.SH,v $
-''' Revision 3.0.1.17  1997/02/28  16:29:31  ram
-''' patch61: documents the runnning environment and the src.U unit
-''' patch61: added warnings for $_a and $_o, as well as "startsh"
-'''
-''' Revision 3.0.1.16  1995/09/25  09:17:48  ram
-''' patch59: documented new ?Y: directive
-''' patch59: fixed my e-mail address
-'''
-''' Revision 3.0.1.15  1995/07/25  14:18:24  ram
-''' patch56: added extra nroff escapes at line heads to keep leading dots
-''' patch56: documented new -G option
-''' patch56: extended description of the Csym.U unit
-''' patch56: now mentions what a compile-link test line should look like
-'''
-''' Revision 3.0.1.14  1995/05/12  12:25:02  ram
-''' patch54: documented new -K switch for knowledgeable users
-'''
-''' Revision 3.0.1.13  1995/01/30  14:46:39  ram
-''' patch49: documented new special units Prefixit.U and Prefixup.U
-'''
-''' Revision 3.0.1.12  1995/01/11  15:39:16  ram
-''' patch45: documents new -O option and new Getfile escape supports
-''' patch45: documents the & escape in Myread and the new cc symbol lookup
-'''
-''' Revision 3.0.1.11  1994/10/29  16:32:38  ram
-''' patch36: added nroff protection for lines beginning with '.'
-''' patch36: documents new ?F: line for file declarations
-''' patch36: added example showing how ./loc can be used
-'''
-''' Revision 3.0.1.10  1994/08/29  16:33:40  ram
-''' patch32: documented new Typedef.U unit for typedef lookup
-'''
-''' Revision 3.0.1.9  1994/06/20  07:10:14  ram
-''' patch30: added -L option for easier unit testing
-''' patch30: new -D and -U options supported by Configure
-'''
-''' Revision 3.0.1.8  1994/05/13  15:29:16  ram
-''' patch27: now understands macro definitions in ?H: lines
-'''
-''' Revision 3.0.1.7  1994/05/06  15:19:25  ram
-''' patch23: documented the new 'p' option in Getfile.U
-'''
-''' Revision 3.0.1.6  1994/01/24  14:19:47  ram
-''' patch16: symbols defined in a unit can be tagged "internal use only"
-''' patch16: documents new MailList.U special unit
-''' patch16: new general <\$variable> macro substitution
-'''
-''' Revision 3.0.1.5  1993/10/16  13:51:50  ram
-''' patch12: new option -M to activate ?M: lines
-''' patch12: documents new ?M: lines format
-''' patch12: new internal Makefile command cm_h_weed for ?M: support
-''' patch12: documents usage for new confmagic.h file
-'''
-''' Revision 3.0.1.4  1993/09/09  11:50:35  ram
-''' patch9: lots of typo fixes and abusive variable substitution problems
-'''
-''' Revision 3.0.1.3  1993/08/30  08:53:51  ram
-''' patch8: wrongly stated that patchlevel.h should not be part of MANIFEST.new
-'''
-''' Revision 3.0.1.2  1993/08/24  12:13:32  ram
-''' patch3: typo fixes
-'''
-''' Revision 3.0.1.1  1993/08/19  06:42:23  ram
-''' patch1: leading config.sh searching was not aborting properly
-'''
-''' Revision 3.0  1993/08/18  12:10:14  ram
-''' Baseline for dist 3.0 netwide release.
-'''
-'''
+.\" @(#) Manual page for metaconfig
+.\"
+.\" $Id$
+.\"
+.\"  Copyright (c) 1991-1997, 2004-2006, Raphael Manfredi
+.\"  
+.\"  You may redistribute only under the terms of the Artistic Licence,
+.\"  as specified in the README file that comes with the distribution.
+.\"  You may reuse parts of this distribution only within the terms of
+.\"  that same Artistic Licence; a copy of which may be found at the root
+.\"  of the source tree for dist 4.0.
+.\"
+.\" $Log: mconfig.SH,v $
+.\" Revision 3.0.1.17  1997/02/28  16:29:31  ram
+.\" patch61: documents the runnning environment and the src.U unit
+.\" patch61: added warnings for $_a and $_o, as well as "startsh"
+.\"
+.\" Revision 3.0.1.16  1995/09/25  09:17:48  ram
+.\" patch59: documented new ?Y: directive
+.\" patch59: fixed my e-mail address
+.\"
+.\" Revision 3.0.1.15  1995/07/25  14:18:24  ram
+.\" patch56: added extra nroff escapes at line heads to keep leading dots
+.\" patch56: documented new -G option
+.\" patch56: extended description of the Csym.U unit
+.\" patch56: now mentions what a compile-link test line should look like
+.\"
+.\" Revision 3.0.1.14  1995/05/12  12:25:02  ram
+.\" patch54: documented new -K switch for knowledgeable users
+.\"
+.\" Revision 3.0.1.13  1995/01/30  14:46:39  ram
+.\" patch49: documented new special units Prefixit.U and Prefixup.U
+.\"
+.\" Revision 3.0.1.12  1995/01/11  15:39:16  ram
+.\" patch45: documents new -O option and new Getfile escape supports
+.\" patch45: documents the & escape in Myread and the new cc symbol lookup
+.\"
+.\" Revision 3.0.1.11  1994/10/29  16:32:38  ram
+.\" patch36: added nroff protection for lines beginning with '.'
+.\" patch36: documents new ?F: line for file declarations
+.\" patch36: added example showing how ./loc can be used
+.\"
+.\" Revision 3.0.1.10  1994/08/29  16:33:40  ram
+.\" patch32: documented new Typedef.U unit for typedef lookup
+.\"
+.\" Revision 3.0.1.9  1994/06/20  07:10:14  ram
+.\" patch30: added -L option for easier unit testing
+.\" patch30: new -D and -U options supported by Configure
+.\"
+.\" Revision 3.0.1.8  1994/05/13  15:29:16  ram
+.\" patch27: now understands macro definitions in ?H: lines
+.\"
+.\" Revision 3.0.1.7  1994/05/06  15:19:25  ram
+.\" patch23: documented the new 'p' option in Getfile.U
+.\"
+.\" Revision 3.0.1.6  1994/01/24  14:19:47  ram
+.\" patch16: symbols defined in a unit can be tagged "internal use only"
+.\" patch16: documents new MailList.U special unit
+.\" patch16: new general <\$variable> macro substitution
+.\"
+.\" Revision 3.0.1.5  1993/10/16  13:51:50  ram
+.\" patch12: new option -M to activate ?M: lines
+.\" patch12: documents new ?M: lines format
+.\" patch12: new internal Makefile command cm_h_weed for ?M: support
+.\" patch12: documents usage for new confmagic.h file
+.\"
+.\" Revision 3.0.1.4  1993/09/09  11:50:35  ram
+.\" patch9: lots of typo fixes and abusive variable substitution problems
+.\"
+.\" Revision 3.0.1.3  1993/08/30  08:53:51  ram
+.\" patch8: wrongly stated that patchlevel.h should not be part of MANIFEST.new
+.\"
+.\" Revision 3.0.1.2  1993/08/24  12:13:32  ram
+.\" patch3: typo fixes
+.\"
+.\" Revision 3.0.1.1  1993/08/19  06:42:23  ram
+.\" patch1: leading config.sh searching was not aborting properly
+.\"
+.\" Revision 3.0  1993/08/18  12:10:14  ram
+.\" Baseline for dist 3.0 netwide release.
+.\"
+.\"
 .de Ex		\" Start of Example
 .sp
 .in +5
@@ -459,9 +459,9 @@ UU/*
 config.sh
 config.h
 .Ef
-'''
-''' O p t i o n s
-'''
+.\"
+.\" O p t i o n s
+.\"
 .SH OPTIONS
 The following options are recognized by \fImetaconfig\fR:
 .TP 15
@@ -541,14 +541,14 @@ The \fIfile\fR can contain blank lines, comment lines introduced with '#', and
 lines containing a single symbol.
 If this option is not supplied, any \fI$exclusions_file\fR variable in
 \fI.package\fR is honored instead.
-'''
-''' T u t o r i a l
-'''
+.\"
+.\" T u t o r i a l
+.\"
 .SH TUTORIAL
 This (long) section is an introduction to \fImetaconfig\fR, in which we will
 learn all the basics. If you already know how to use \fImetaconfig\fR, you
 may safely skip to the next section.
-'''
+.\"
 .SS Overview
 .PP
 Usually when you want to get some source package to compile on a given
@@ -601,7 +601,7 @@ unit being responsible for defining a small number of shell and/or C
 symbols. Units are assembled together at the final stage, honoring
 the dependency graph (one unit may need the result of several other
 units which are then placed before in the script).
-'''
+.\"
 .SS Symbols
 .PP
 Symbols are the most important thing in the \fImetaconfig\fR world. They
@@ -626,7 +626,7 @@ paragraph could sound. In a C file, you need to include the Configure-produced
 \fIconfig.h\fR file, and you must wrap your shell script or Makefile in a .SH
 file and you may reference the shell symbol only in the variable
 substitution part of that .SH file. More on this later.
-'''
+.\"
 .SS Source Files
 .PP
 Symbols may only appear in a limited set of source files, because
@@ -644,7 +644,7 @@ substitutions apply. Actually, \fIconfig.h\fR is produced by running the
 \fImetaconfig\fR-produced \fIconfig_h.SH\fR file, again using variable
 substitution. So we're going to look at that a little more closely since
 this is the heart of the whole \fIconfiguration\fR scheme...
-'''
+.\"
 .SS Variable Substitution
 .PP
 There is shell construct called \fIhere document\fR which enables a
@@ -685,7 +685,7 @@ echo \$\&tar
 .Ef
 The first here document has its content interpreted whilst the second
 one is output as-is. Both are useful in a .SH script, as we are about to see.
-'''
+.\"
 .SS Using .SH Scripts
 .PP
 A .SH script is usually produced by running the \fIMakeSH\fR script other
@@ -824,7 +824,7 @@ stored as a 64 bits quantity, \fIconfig.sh\fR will set \fIintsize\fR to
 On this machine, the int type is 8 bytes
 .Ef
 which is correct. Congratulations! We have just configured a shell script!!
-'''
+.\"
 .SS Producing config.h
 .PP
 We can now have a look at the way \fIconfig.h\fR is produced out of
@@ -978,7 +978,7 @@ configured C code, since \fImetaconfig\fR will know that you need
 those symbols and will generate a suitable \fIconfig_h.SH\fR file as
 well as all the necessary code in \fIConfigure\fR to compute a
 proper value for them (by assigning values to associated shell variables).
-'''
+.\"
 .SS Running Metaconfig
 .PP
 Let's focus on the \fImetaconfig\fR program for a while to understand how
@@ -1039,7 +1039,7 @@ required are removed and a second Makefile is generated. This time, we know
 about all the units and their respective orders, optional units having been
 removed and default values computed for their shell symbols. The \fIConfigure\fR
 script can then be generated, along with \fIconfig_h.SH\fR. We're done.
-'''
+.\"
 .SS Conventions
 .PP
 Proper conventions needs to be followed to make the whole process sound.
@@ -1069,7 +1069,7 @@ answer in \fI\$dflt\fR and places the user answer in \fI\$ans\fR. This is
 not documented in this manual page: you have to go and look at the unit
 itself to understand which variables are used and how the unit is to be
 used.
-'''
+.\"
 .SS Using The Glossary
 .PP
 The Glossary file is automatically produced by the \fImakegloss\fR script,
@@ -1084,7 +1084,7 @@ about \fImetaconfig\fR to do so quickly and efficiently. However, never
 forget to properly document your work in the ?S: and ?C: lines, or other
 people will not be able to reuse it. Remember about the time where you
 had only the Glossary and this manual page to get started.
-'''
+.\"
 .SS Conclusion
 .PP
 Now that you know the \fImetaconfig\fR basics, you should read the
@@ -1095,7 +1095,7 @@ commands you are allowed to use.
 .SH REFERENCE
 This section documents the internals of \fImetaconfig\fR, basically the
 unit syntax, the special units you should know about and the hint files.
-'''
+.\"
 .SS General Unit Syntax
 .PP
 A metaconfig unit is divided into two distinct parts. The header section
@@ -1303,7 +1303,7 @@ hints that can be used.
 ?INIT:\fIinitialization code\fR
 The initialization code specified by this line will be loaded at the top
 of the \fIConfigure\fR script provided the unit is needed.
-'''
+.\"
 .SS C Symbol Aliasing
 .PP
 Sometimes it is not possible to rely on \fImetaconfig\fR's own default
@@ -1383,7 +1383,7 @@ It simply tries to compile a sample C program using the \fIconst\fR keyword.
 If it can, then it will define \fI\$\&d_const\fR via the \fI\$\&setvar\fR
 fonction (defined by the \fISetvar.U\fR unit). See the paragraph about
 special units for more details.
-'''
+.\"
 .SS Make Commands
 .PP
 On the ?MAKE: command line, you may write a shell command to be executed as-is
@@ -1448,7 +1448,7 @@ As a side note, \fImetaconfig\fR generates a \fI-cond\fR command internally
 to deal with conditional dependencies. You should not use it by yourself,
 but you will see it if scanning the generated \fIMakefile\fR in the \fI.MT\fR
 directory.
-'''
+.\"
 .SS Hardwired Macros
 .PP
 The following macros are recognized by the \fIwipe\fR command and subsituted
@@ -1491,7 +1491,7 @@ which is replaced at Configure-generation time by the value of \fIvariable\fR
 taken from your \fI.package\fR file. Eventually, the old hardwired macro
 format will disappear, and <\$baserev> will replace <BASEREV> in all the
 supplied units.
-'''
+.\"
 .SS Special Units
 .PP
 The following special units are used to factorize code and provide higher
@@ -1781,7 +1781,7 @@ This unit produces the \fIwhoa\fR script, which emits a warning when the
 its old previous value held in \fI\$was\fR. Upon return, \fI\$td\fR and
 \fI\$tu\fR hold the proper value to \fIdefine\fR or \fIundef\fR the variable.
 See examples in \fIInlibc.U\fR.
-'''
+.\"
 .SS Builtin Pre-processor
 .PP
 Each unit to be included in \fIConfigure\fR is ran through a built-in
@@ -1881,7 +1881,7 @@ done
 .Ef
 and have an extra loop trying two successive values for the \fIs_timezone\fR
 variable, but only if needed.
-'''
+.\"
 .SS Obsolete Symbols
 .PP
 Obsolete symbols are preserved to ease the transition with older
@@ -1895,7 +1895,7 @@ The lifetime for obsolete symbols is one full revision, i.e. they will
 be removed when the next base revision is issued (patch upgrades do not
 count of course). Therefore, it is wise to translate your sources and
 start using the new symbols as soon as possible.
-'''
+.\"
 .SS Configure Hints
 .PP
 It may happen that the internal configuration logic makes the wrong choices.
@@ -1945,7 +1945,7 @@ Note that you don't have to provide \fIall\fR the hints known by
 possible choice. The heuristic tests ran to compute the possible hint
 candidates are flaky. If you have new values or different tests, please send
 them to me...
-'''
+.\"
 .SS Overriding Choices
 .PP
 If you create a \fIconfig.over\fR file in the top level directory,
@@ -1956,7 +1956,7 @@ you a chance to patch the values stored in there.
 This is distinct from the hints approach in that it is a local file, which
 the user is free to create for his own usage. You should not provide such
 a file yourself, but let the user know about this possibility.
-'''
+.\"
 .SS Configure Options
 .PP
 The \fIConfigure\fR script may be called with some options specified on the
@@ -2028,7 +2028,7 @@ possible to use '\fB-U\fI symbol\fR' which will set \fIsymbol\fR to 'undef'.
 Print the version number of the \fImetaconfig\fR that generated this
 .I Configure
 script and exit.
-'''
+.\"
 .SS Running Environment
 Upon starting, \fIConfigure\fR creates a local \fIUU\fR directory and runs
 from there. The directory is removed when Configure ends, but this means
@@ -2057,7 +2057,7 @@ When running \fIConfigure\fR remotely, the .SH files are extracted in the
 build directory, not in the source tree. However, it requires some kind of
 a \fImake\fR support to be able to compile things in a build directory whilst
 the sources lie elsewhere.
-'''
+.\"
 .SS Using Magic Redefinitions
 .PP
 By making use of the \fB\-M\fR switch, some magic remappings may take place
@@ -2077,7 +2077,7 @@ on \fImemcpy()\fR if no \fIbcopy()\fR is available locally, or transform
 bother about the \fIHAS_VFORK\fR symbol.
 .PP
 This configuration magic is documented in the Glossary file.
-'''
+.\"
 .SS Unit Templates
 .PP
 There is a set of unit templates in the \fImetaconfig\fR source directory,

--- a/mcon/man/mlint.SH
+++ b/mcon/man/mlint.SH
@@ -18,54 +18,54 @@ echo "Extracting mcon/man/metalint.$manext (with variable substitutions)"
 $rm -f metalint.$manext
 $spitshell >metalint.$manext <<!GROK!THIS!
 .TH METALINT $manext "Version $VERSION PL$PATCHLEVEL"
-''' @(#) Manual page for metalint
-'''
-''' $Id$
-'''
-'''  Copyright (c) 1991-1997, 2004-2006, Raphael Manfredi
-'''  
-'''  You may redistribute only under the terms of the Artistic Licence,
-'''  as specified in the README file that comes with the distribution.
-'''  You may reuse parts of this distribution only within the terms of
-'''  that same Artistic Licence; a copy of which may be found at the root
-'''  of the source tree for dist 4.0.
-'''
-''' $Log: mlint.SH,v $
-''' Revision 3.0.1.9  1997/02/28  16:30:25  ram
-''' patch61: new "create" and "empty" lint directives
-''' patch61: documented new messages
-'''
-''' Revision 3.0.1.8  1995/09/25  09:18:07  ram
-''' patch59: documented new ?Y: directive
-''' patch59: fixed my e-mail address
-'''
-''' Revision 3.0.1.7  1995/07/25  14:18:51  ram
-''' patch56: added two new warnings for : comments lines in Configure
-'''
-''' Revision 3.0.1.6  1994/10/29  16:33:56  ram
-''' patch36: documents new ?F: lines and the related metalint warnings
-''' patch36: removed statement in BUGS since all warnings may now be shut
-'''
-''' Revision 3.0.1.5  1994/05/06  15:20:30  ram
-''' patch23: added -L switch to override public unit repository path
-''' patch23: two new warnings concerning last unit lines
-'''
-''' Revision 3.0.1.4  1994/01/24  14:20:39  ram
-''' patch16: can now easily suppress warning about made "special units"
-'''
-''' Revision 3.0.1.3  1993/11/10  17:37:39  ram
-''' patch14: documents stale ?M: dependency check
-'''
-''' Revision 3.0.1.2  1993/10/16  13:52:23  ram
-''' patch12: added support for ?M: lines and fixed some typos
-'''
-''' Revision 3.0.1.1  1993/08/19  06:42:24  ram
-''' patch1: leading config.sh searching was not aborting properly
-'''
-''' Revision 3.0  1993/08/18  12:10:15  ram
-''' Baseline for dist 3.0 netwide release.
-'''
-'''
+.\" @(#) Manual page for metalint
+.\"
+.\" $Id$
+.\"
+.\"  Copyright (c) 1991-1997, 2004-2006, Raphael Manfredi
+.\"  
+.\"  You may redistribute only under the terms of the Artistic Licence,
+.\"  as specified in the README file that comes with the distribution.
+.\"  You may reuse parts of this distribution only within the terms of
+.\"  that same Artistic Licence; a copy of which may be found at the root
+.\"  of the source tree for dist 4.0.
+.\"
+.\" $Log: mlint.SH,v $
+.\" Revision 3.0.1.9  1997/02/28  16:30:25  ram
+.\" patch61: new "create" and "empty" lint directives
+.\" patch61: documented new messages
+.\"
+.\" Revision 3.0.1.8  1995/09/25  09:18:07  ram
+.\" patch59: documented new ?Y: directive
+.\" patch59: fixed my e-mail address
+.\"
+.\" Revision 3.0.1.7  1995/07/25  14:18:51  ram
+.\" patch56: added two new warnings for : comments lines in Configure
+.\"
+.\" Revision 3.0.1.6  1994/10/29  16:33:56  ram
+.\" patch36: documents new ?F: lines and the related metalint warnings
+.\" patch36: removed statement in BUGS since all warnings may now be shut
+.\"
+.\" Revision 3.0.1.5  1994/05/06  15:20:30  ram
+.\" patch23: added -L switch to override public unit repository path
+.\" patch23: two new warnings concerning last unit lines
+.\"
+.\" Revision 3.0.1.4  1994/01/24  14:20:39  ram
+.\" patch16: can now easily suppress warning about made "special units"
+.\"
+.\" Revision 3.0.1.3  1993/11/10  17:37:39  ram
+.\" patch14: documents stale ?M: dependency check
+.\"
+.\" Revision 3.0.1.2  1993/10/16  13:52:23  ram
+.\" patch12: added support for ?M: lines and fixed some typos
+.\"
+.\" Revision 3.0.1.1  1993/08/19  06:42:24  ram
+.\" patch1: leading config.sh searching was not aborting properly
+.\"
+.\" Revision 3.0  1993/08/18  12:10:15  ram
+.\" Baseline for dist 3.0 netwide release.
+.\"
+.\"
 .SH NAME
 metalint \- a metaconfig unit consistency checker
 .SH SYNOPSIS

--- a/mcon/man/mxref.SH
+++ b/mcon/man/mxref.SH
@@ -18,35 +18,35 @@ echo "Extracting mcon/man/metaxref.$manext (with variable substitutions)"
 $rm -f metaxref.$manext
 $spitshell >metaxref.$manext <<!GROK!THIS!
 .TH METAXREF $manext "Version $VERSION PL$PATCHLEVEL"
-''' @(#) Manual page for metaxref
-'''
-''' $Id$
-'''
-'''  Copyright (c) 1991-1997, 2004-2006, Raphael Manfredi
-'''  
-'''  You may redistribute only under the terms of the Artistic Licence,
-'''  as specified in the README file that comes with the distribution.
-'''  You may reuse parts of this distribution only within the terms of
-'''  that same Artistic Licence; a copy of which may be found at the root
-'''  of the source tree for dist 4.0.
-'''
-''' $Log: mxref.SH,v $
-''' Revision 3.0.1.4  1997/02/28  16:30:39  ram
-''' patch61: new -L option to match metaconfig and metalint
-'''
-''' Revision 3.0.1.3  1994/10/29  16:34:26  ram
-''' patch36: the leading .TH was referring to metaconfig
-'''
-''' Revision 3.0.1.2  1993/10/16  13:52:46  ram
-''' patch12: added BUGS section
-'''
-''' Revision 3.0.1.1  1993/08/19  06:42:25  ram
-''' patch1: leading config.sh searching was not aborting properly
-'''
-''' Revision 3.0  1993/08/18  12:10:15  ram
-''' Baseline for dist 3.0 netwide release.
-'''
-'''
+.\" @(#) Manual page for metaxref
+.\"
+.\" $Id$
+.\"
+.\"  Copyright (c) 1991-1997, 2004-2006, Raphael Manfredi
+.\"  
+.\"  You may redistribute only under the terms of the Artistic Licence,
+.\"  as specified in the README file that comes with the distribution.
+.\"  You may reuse parts of this distribution only within the terms of
+.\"  that same Artistic Licence; a copy of which may be found at the root
+.\"  of the source tree for dist 4.0.
+.\"
+.\" $Log: mxref.SH,v $
+.\" Revision 3.0.1.4  1997/02/28  16:30:39  ram
+.\" patch61: new -L option to match metaconfig and metalint
+.\"
+.\" Revision 3.0.1.3  1994/10/29  16:34:26  ram
+.\" patch36: the leading .TH was referring to metaconfig
+.\"
+.\" Revision 3.0.1.2  1993/10/16  13:52:46  ram
+.\" patch12: added BUGS section
+.\"
+.\" Revision 3.0.1.1  1993/08/19  06:42:25  ram
+.\" patch1: leading config.sh searching was not aborting properly
+.\"
+.\" Revision 3.0  1993/08/18  12:10:15  ram
+.\" Baseline for dist 3.0 netwide release.
+.\"
+.\"
 .SH NAME
 metaxref \- builds cross-reference file/unit/item information
 .SH SYNOPSIS

--- a/pat/pat.man
+++ b/pat/pat.man
@@ -1,42 +1,42 @@
 .rn '' }`
-''' $Id$
-'''
-'''  Copyright (c) 1991-1997, 2004-2006, Raphael Manfredi
-'''  
-'''  You may redistribute only under the terms of the Artistic Licence,
-'''  as specified in the README file that comes with the distribution.
-'''  You may reuse parts of this distribution only within the terms of
-'''  that same Artistic Licence; a copy of which may be found at the root
-'''  of the source tree for dist 4.0.
-'''
-''' $Log: pat.man,v $
-''' Revision 3.0.1.7  1997/02/28  16:32:45  ram
-''' patch61: documents contents of the message sent by patnotify
-'''
-''' Revision 3.0.1.6  1995/09/25  09:20:41  ram
-''' patch59: new -i option for patsend to add extra instructions
-'''
-''' Revision 3.0.1.5  1995/05/12  12:25:28  ram
-''' patch54: updated my e-mail address
-'''
-''' Revision 3.0.1.4  1994/10/29  16:38:31  ram
-''' patch36: documents new patlog script and the files it uses
-''' patch36: the RCS layer section has been extended slightly
-'''
-''' Revision 3.0.1.3  1993/08/27  14:40:19  ram
-''' patch7: random cleanup
-'''
-''' Revision 3.0.1.2  1993/08/25  14:05:02  ram
-''' patch6: new -q option for patsend and patnotify
-'''
-''' Revision 3.0.1.1  1993/08/24  12:15:42  ram
-''' patch3: added patnotify and patsnap
-''' patch3: patcol has a new -S option
-''' patch3: the users file built by mailagent is now listed under FILES
-'''
-''' Revision 3.0  1993/08/18  12:10:37  ram
-''' Baseline for dist 3.0 netwide release.
-'''
+.\" $Id$
+.\"
+.\"  Copyright (c) 1991-1997, 2004-2006, Raphael Manfredi
+.\"  
+.\"  You may redistribute only under the terms of the Artistic Licence,
+.\"  as specified in the README file that comes with the distribution.
+.\"  You may reuse parts of this distribution only within the terms of
+.\"  that same Artistic Licence; a copy of which may be found at the root
+.\"  of the source tree for dist 4.0.
+.\"
+.\" $Log: pat.man,v $
+.\" Revision 3.0.1.7  1997/02/28  16:32:45  ram
+.\" patch61: documents contents of the message sent by patnotify
+.\"
+.\" Revision 3.0.1.6  1995/09/25  09:20:41  ram
+.\" patch59: new -i option for patsend to add extra instructions
+.\"
+.\" Revision 3.0.1.5  1995/05/12  12:25:28  ram
+.\" patch54: updated my e-mail address
+.\"
+.\" Revision 3.0.1.4  1994/10/29  16:38:31  ram
+.\" patch36: documents new patlog script and the files it uses
+.\" patch36: the RCS layer section has been extended slightly
+.\"
+.\" Revision 3.0.1.3  1993/08/27  14:40:19  ram
+.\" patch7: random cleanup
+.\"
+.\" Revision 3.0.1.2  1993/08/25  14:05:02  ram
+.\" patch6: new -q option for patsend and patnotify
+.\"
+.\" Revision 3.0.1.1  1993/08/24  12:15:42  ram
+.\" patch3: added patnotify and patsnap
+.\" patch3: patcol has a new -S option
+.\" patch3: the users file built by mailagent is now listed under FILES
+.\"
+.\" Revision 3.0  1993/08/18  12:10:37  ram
+.\" Baseline for dist 3.0 netwide release.
+.\"
 .de Sh
 .br
 .ne 5
@@ -48,10 +48,10 @@
 .if t .sp .5v
 .if n .sp
 ..
-'''
-'''     Set up \*(-- to give an unbreakable dash;
-'''     string Tr holds user defined translation string.
-'''
+.\"
+.\"     Set up \*(-- to give an unbreakable dash;
+.\"     string Tr holds user defined translation string.
+.\"
 .ie n \{\
 .tr \(*W-\*(Tr
 .ds -- \(*W-
@@ -408,9 +408,9 @@ may be used from the top level directory or within the \fIbugs\fR directory.
 It will list all the patches and their \fISubject:\fR lines. This program
 knows about compressed patches and will decompress them while producing
 the listing.
-'''
-''' R C S   L a y e r
-'''
+.\"
+.\" R C S   L a y e r
+.\"
 .SH RCS LAYER
 This section describes the RCS layer, in case  something in the tools breaks,
 so that you may fix your RCS files and restart the operation.


### PR DESCRIPTION
The commenting scheme used in the man pages was three consecutive single
quotes (`'''`) at the beginning of a line. his works, but `gtroff` gives
a warning about an undefined macro (namely `'''`), which is harmless, but
irritating.

To avoid this, this commit changes the schema to start the line with
`.\"` which causes the line to be treated as an undefined request and
thus ignored completely.

Signed-off-by: Manoj Srivastava <srivasta@debian.org>

[updated to current dist by Dominic Hargreaves <dom@earth.li>]