### PR TITLE
Fix bug when $exclusions_file is specified in .package file

### DIFF
--- a/mcon/mconfig.SH
+++ b/mcon/mconfig.SH
@@ -70,8 +70,6 @@ chop($date = `date`);
 use Getopt::Std;
 &usage unless getopts("dhkmostvwGMVL:X:");
 
-my %excluded_symbol;
-read_exclusions($opt_X);
 $MC = $opt_L if $opt_L;			# May override public library path
 $MC = &tilda_expand($MC);		# ~name expansion
 chop($WD = `pwd`);				# Working directory
@@ -93,6 +91,8 @@ unlink 'Wanted' unless $opt_w;			# Wanted rebuilt if no -w
 unlink 'Obsolete' unless $opt_w;		# Obsolete file rebuilt if no -w
 &readpackage;							# Merely get the package's name
 &init;									# Various initializations
+my %excluded_symbol;
+read_exclusions($opt_X);				# Load -X or .package equivalent
 `mkdir .MT 2>&1` unless -d '.MT';		# For private temporary files
 
 &locate_units;				# Fill in @ARGV with a unit list

--- a/mcon/mxref.SH
+++ b/mcon/mxref.SH
@@ -64,8 +64,6 @@ use Getopt::Std;
 
 chop($date = `date`);
 chop($WD = `pwd`);				# Working directory
-my %excluded_symbol;
-read_exclusions($opt_X);
 $MC = $opt_L if $opt_L;			# May override  library path
 $MC = &tilda_expand($MC);		# ~name expansion
 chdir $MC || die "Can't chdir to $MC: $!\n";
@@ -81,7 +79,10 @@ if ($opt_V) {
 
 $NEWMANI = $opt_f || (-f 'MANIFEST.new' ? 'MANIFEST.new' : 'MANIFEST');
 
+&readpackage;							# Merely get the package's name
 &init;									# Various initializations
+my %excluded_symbol;
+read_exclusions($opt_X);				# Load -X or .package equivalent
 `mkdir .MT 2>&1` unless -d '.MT';		# For private temporary files
 unlink 'Obsolete';						# Obsolete file rebuilt
 


### PR DESCRIPTION
The actual programs were trying to load the exclusions file before reading .package (or even, in one case, without trying to read it at all). I failed to notice this because I had a "-X" option that duplicated the intended use of the setting in my .package file.

This change has been tested against Perl, run with no -X option, but with the exclusions file specified in .package.